### PR TITLE
fix: macOS compatibility for `just install`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -147,7 +147,12 @@ build: bundle-frontend
     echo "Building version: $build_version"
 
     # Temporarily patch pyproject.toml version for the build
-    sed -i "s/^version = \".*\"/version = \"${build_version}\"/" pyproject.toml
+    # Use python instead of sed -i for macOS/Linux portability
+    python3 -c "
+    import re, pathlib
+    p = pathlib.Path('pyproject.toml')
+    p.write_text(re.sub(r'^version = \".*\"', 'version = \"${build_version}\"', p.read_text(), count=1, flags=re.MULTILINE))
+    "
     trap 'git checkout pyproject.toml 2>/dev/null || true' EXIT
     uv build
 


### PR DESCRIPTION
## Summary

- `sed -i` in the `build` recipe uses GNU syntax, which fails on macOS (BSD `sed` requires a backup extension: `sed -i '' ...`)
- Replaced with a `python3` one-liner using `re.sub` + `pathlib` — python is already a build dependency, so this is zero-cost and portable across Linux/macOS

## Error on macOS

```
sed: 1: "pyproject.toml
": extra characters at the end of p command
error: Recipe `build` failed with exit code 1
```

## Test plan

- [x] Verified `just install` succeeds on macOS (Apple Silicon, Darwin 25.3.0)
- [x] Verified `pyproject.toml` is correctly patched during build and restored by the trap afterward
- [x] Dev build version string works: `0.2.0.dev0+g413c6ce9.dirty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)