### PR TITLE
feat(sidebar): drag-to-resize handle with persisted width

### DIFF
--- a/frontend/e2e/sidebar.spec.ts
+++ b/frontend/e2e/sidebar.spec.ts
@@ -5,7 +5,7 @@ test.describe("Sidebar file tree", () => {
     await page.goto("/");
 
     // Wait for the sidebar to load
-    const sidebar = page.locator(".w-72");
+    const sidebar = page.locator('[data-testid="sidebar"]');
     await expect(sidebar).toBeVisible();
 
     // Verify subdir is visible in the sidebar tree
@@ -33,7 +33,7 @@ test.describe("Sidebar file tree", () => {
   test("navigating via sidebar updates URL", async ({ page }) => {
     await page.goto("/");
 
-    const sidebar = page.locator(".w-72");
+    const sidebar = page.locator('[data-testid="sidebar"]');
     await expect(sidebar).toBeVisible();
 
     // Click on a markdown file in the sidebar

--- a/frontend/e2e/sidebar_resize.spec.ts
+++ b/frontend/e2e/sidebar_resize.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E tests for resizable sidebar.
+ *
+ * Selector contract:
+ *   [data-testid="sidebar"]              — the sidebar container
+ *   [data-testid="sidebar-resize-handle"] — the drag handle on the right edge
+ *
+ * Persistence contract:
+ *   localStorage key  "vantage:sidebarWidth"  holds the px width as a string.
+ *
+ * Range contract:
+ *   width clamped to [200, 800].
+ */
+
+const MIN_WIDTH = 200;
+const MAX_WIDTH = 800;
+const DEFAULT_WIDTH = 288;
+
+async function getSidebarWidth(page: import("@playwright/test").Page) {
+  const sidebar = page.locator('[data-testid="sidebar"]');
+  await expect(sidebar).toBeVisible();
+  const box = await sidebar.boundingBox();
+  if (!box) throw new Error("sidebar has no bounding box");
+  return Math.round(box.width);
+}
+
+async function dragHandleBy(
+  page: import("@playwright/test").Page,
+  deltaX: number,
+) {
+  const handle = page.locator('[data-testid="sidebar-resize-handle"]');
+  await expect(handle).toBeVisible();
+  const box = await handle.boundingBox();
+  if (!box) throw new Error("resize handle has no bounding box");
+  const startX = box.x + box.width / 2;
+  const startY = box.y + box.height / 2;
+  const widthBefore = await getSidebarWidth(page);
+  const viewport = page.viewportSize();
+  const maxX = viewport ? viewport.width - 1 : 1280;
+  // Clamp final target to viewport — pointermove events outside the viewport
+  // aren't reliably delivered. Drags that push past the clamp boundary
+  // still trigger the implementation's own min/max clamp.
+  const targetX = Math.max(1, Math.min(maxX, startX + deltaX));
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  // Drag in small steps so each pointermove listener fires.
+  const steps = 10;
+  for (let i = 1; i <= steps; i++) {
+    await page.mouse.move(startX + ((targetX - startX) * i) / steps, startY);
+  }
+  await page.mouse.up();
+  // Wait for the sidebar's width to actually reflect the drag before returning.
+  if (deltaX !== 0) {
+    await page
+      .locator('[data-testid="sidebar"]')
+      .evaluate(
+        (el, prev) =>
+          new Promise<void>((resolve) => {
+            const start = Date.now();
+            const check = () => {
+              const w = Math.round(el.getBoundingClientRect().width);
+              if (w !== prev || Date.now() - start > 500) resolve();
+              else requestAnimationFrame(check);
+            };
+            check();
+          }),
+        widthBefore,
+      );
+  }
+}
+
+// Tests run serially within this describe so the small drag windows aren't
+// disturbed by the dev server's slower response under heavy parallel load.
+// The implementation itself works correctly under parallel use; this is purely
+// a test-runtime concern.
+test.describe.configure({ mode: "serial" });
+
+test.describe("Sidebar resize", () => {
+  test.beforeEach(async ({ page }) => {
+    // Start each test with a clean stored width so the default is predictable.
+    // We use evaluate-after-goto rather than addInitScript so that subsequent
+    // page.reload() calls in the test body don't wipe the value we just persisted.
+    await page.goto("/");
+    await page.evaluate(() => {
+      try {
+        localStorage.removeItem("vantage:sidebarWidth");
+      } catch {
+        /* ignore */
+      }
+    });
+    await page.reload();
+    // Wait for the app to leave its "Loading…" state. The sidebar (and its
+    // resize handle) only mount once repos have been fetched; without this,
+    // a drag triggered too early will race against an unmounted handle.
+    await expect(page.getByText("Loading...")).toHaveCount(0, {
+      timeout: 10_000,
+    });
+    await expect(page.locator('[data-testid="sidebar"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="sidebar-resize-handle"]'),
+    ).toBeVisible();
+  });
+
+  test("renders sidebar at the default width", async ({ page }) => {
+    const width = await getSidebarWidth(page);
+    expect(width).toBe(DEFAULT_WIDTH);
+  });
+
+  test("exposes a resize handle on the right edge of the sidebar", async ({
+    page,
+  }) => {
+    const sidebar = page.locator('[data-testid="sidebar"]');
+    const handle = page.locator('[data-testid="sidebar-resize-handle"]');
+    await expect(sidebar).toBeVisible();
+    await expect(handle).toBeVisible();
+
+    const sidebarBox = await sidebar.boundingBox();
+    const handleBox = await handle.boundingBox();
+    if (!sidebarBox || !handleBox)
+      throw new Error("missing bounding box for sidebar or handle");
+
+    // Handle's horizontal center should sit at (or essentially at) the sidebar's right edge.
+    const sidebarRight = sidebarBox.x + sidebarBox.width;
+    const handleCenter = handleBox.x + handleBox.width / 2;
+    expect(Math.abs(handleCenter - sidebarRight)).toBeLessThanOrEqual(4);
+  });
+
+  test("dragging the handle right grows the sidebar", async ({ page }) => {
+    const before = await getSidebarWidth(page);
+    await dragHandleBy(page, 100);
+    const after = await getSidebarWidth(page);
+    // Allow ±2px for sub-pixel rounding.
+    expect(after).toBeGreaterThanOrEqual(before + 100 - 2);
+    expect(after).toBeLessThanOrEqual(before + 100 + 2);
+  });
+
+  test("dragging the handle left shrinks the sidebar", async ({ page }) => {
+    const before = await getSidebarWidth(page);
+    await dragHandleBy(page, -50);
+    const after = await getSidebarWidth(page);
+    expect(after).toBeGreaterThanOrEqual(before - 50 - 2);
+    expect(after).toBeLessThanOrEqual(before - 50 + 2);
+  });
+
+  test("width clamps to MIN when dragged too far left", async ({ page }) => {
+    // Drag far left — well below MIN.
+    await dragHandleBy(page, -1000);
+    const after = await getSidebarWidth(page);
+    expect(after).toBe(MIN_WIDTH);
+  });
+
+  test("width clamps to MAX when dragged too far right", async ({ page }) => {
+    // Drag far right — well above MAX.
+    await dragHandleBy(page, 2000);
+    const after = await getSidebarWidth(page);
+    expect(after).toBe(MAX_WIDTH);
+  });
+
+  test("width persists across reload via localStorage", async ({ page }) => {
+    await dragHandleBy(page, 80);
+    const after = await getSidebarWidth(page);
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("vantage:sidebarWidth"),
+    );
+    expect(stored).not.toBeNull();
+    expect(parseInt(stored as string, 10)).toBe(after);
+
+    await page.reload();
+    await expect(page.getByText("Loading...")).toHaveCount(0, {
+      timeout: 10_000,
+    });
+    const reloaded = await getSidebarWidth(page);
+    expect(reloaded).toBe(after);
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -14,12 +14,12 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: { ...devices["Desktop Chrome"], channel: "chrome" },
     },
   ],
   webServer: {
     command:
-      "cd .. && TARGET_REPO=tests/e2e/test_repo uv run vantage serve --port 8101 & VITE_API_TARGET=http://localhost:8101 VITE_WS_TARGET=ws://localhost:8101 npm run dev -- --port 5201",
+      "cd .. && TARGET_REPO=tests/e2e/test_repo uv run vantage serve --port 8101 --no-open & VITE_API_TARGET=http://localhost:8101 VITE_WS_TARGET=ws://localhost:8101 npm run dev -- --port 5201",
     url: "http://localhost:5201",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/frontend/src/pages/ViewerPage.tsx
+++ b/frontend/src/pages/ViewerPage.tsx
@@ -140,6 +140,60 @@ export const ViewerPage: React.FC = () => {
       return false;
     }
   });
+  const SIDEBAR_MIN_WIDTH = 200;
+  const SIDEBAR_MAX_WIDTH = 800;
+  const SIDEBAR_DEFAULT_WIDTH = 288; // matches the old `w-72`
+  const [sidebarWidth, setSidebarWidth] = useState<number>(() => {
+    try {
+      const raw = localStorage.getItem("vantage:sidebarWidth");
+      const v = raw == null ? NaN : parseInt(raw, 10);
+      return Number.isFinite(v) &&
+        v >= SIDEBAR_MIN_WIDTH &&
+        v <= SIDEBAR_MAX_WIDTH
+        ? v
+        : SIDEBAR_DEFAULT_WIDTH;
+    } catch {
+      return SIDEBAR_DEFAULT_WIDTH;
+    }
+  });
+  const [isResizingSidebar, setIsResizingSidebar] = useState(false);
+  const isResizingSidebarRef = useRef(false);
+  useEffect(() => {
+    try {
+      localStorage.setItem("vantage:sidebarWidth", String(sidebarWidth));
+    } catch {
+      /* ignore */
+    }
+  }, [sidebarWidth]);
+  // Always-attached window listeners gated by a ref. Attaching once at mount
+  // (rather than per-drag via a state-driven effect) eliminates the race where
+  // rapid pointermove events arrive before a state-update-triggered effect re-runs.
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      if (!isResizingSidebarRef.current) return;
+      const w = Math.max(
+        SIDEBAR_MIN_WIDTH,
+        Math.min(SIDEBAR_MAX_WIDTH, e.clientX),
+      );
+      setSidebarWidth(w);
+    };
+    const onUp = () => {
+      if (!isResizingSidebarRef.current) return;
+      isResizingSidebarRef.current = false;
+      setIsResizingSidebar(false);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [showRaw, setShowRaw] = useState(false);
   const [copied, setCopied] = useState(false);
   const [pathCopied, setPathCopied] = useState(false);
@@ -689,8 +743,10 @@ export const ViewerPage: React.FC = () => {
         {/* Sidebar - hidden on repo picker page, collapsible on desktop */}
         {showSidebar && (
           <div
+            data-testid="sidebar"
+            style={{ width: `${sidebarWidth}px` }}
             className={cn(
-              "w-72 border-r border-slate-200 dark:border-slate-700 flex flex-col bg-white dark:bg-slate-800 shadow-sm",
+              "flex-shrink-0 border-r border-slate-200 dark:border-slate-700 flex flex-col bg-white dark:bg-slate-800 shadow-sm relative",
               "fixed inset-y-0 left-0 z-50 transition-transform duration-200 ease-in-out md:relative md:z-auto",
               sidebarOpen ? "translate-x-0" : "-translate-x-full",
               sidebarCollapsed
@@ -866,6 +922,28 @@ export const ViewerPage: React.FC = () => {
                 </div>
               </div>
             )}
+            {/* Resize handle — desktop only, hidden when sidebar is collapsed/closed.
+                pointerdown flips a ref and visible-state flag; the actual drag
+                logic lives in always-attached window listeners (see the useEffect
+                near sidebarWidth init). */}
+            <div
+              data-testid="sidebar-resize-handle"
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Resize sidebar"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                isResizingSidebarRef.current = true;
+                setIsResizingSidebar(true);
+                document.body.style.cursor = "col-resize";
+                document.body.style.userSelect = "none";
+              }}
+              className={cn(
+                "hidden md:block absolute top-0 right-0 h-full w-1 -mr-0.5 cursor-col-resize z-10 touch-none",
+                "hover:bg-blue-400/60 active:bg-blue-500/80 transition-colors",
+                isResizingSidebar && "bg-blue-500/80",
+              )}
+            />
           </div>
         )}
 


### PR DESCRIPTION
Closes #35.

## Summary

- Adds a vertical drag handle on the right edge of the sidebar so users can widen or narrow it instead of being stuck at a fixed 288px.
- Width is clamped to **[200, 800]** px and persisted to `localStorage` as `vantage:sidebarWidth` (survives reloads, same convention as `vantage:sidebarCollapsed`).
- Default 288 matches the previous `w-72`, so the no-config first-run experience is unchanged.
- Hidden on mobile (`md:`-only); on small screens the sidebar is a slide-out drawer rather than a fixed pane.

## Implementation notes

- `pointermove` / `pointerup` / `pointercancel` listeners are attached **once** at mount and gated by a ref. An earlier attempt that registered listeners inside a state-driven `useEffect` raced against rapid pointermove events under e2e load (Playwright fires several within ~10ms; React's effect didn't run in time).
- The handle is `absolute right-0 w-1` with `-mr-0.5` so half straddles the sidebar edge — gives a wider hit-target without a visible thicker rule.
- `data-testid` attributes added on the sidebar and handle for test stability. The existing `sidebar.spec.ts` is updated to use `[data-testid="sidebar"]` instead of `.w-72` (which is now gone).

## Test changes

- New `e2e/sidebar_resize.spec.ts`: 7 cases covering default width, handle placement, drag-to-grow, drag-to-shrink, MIN clamp, MAX clamp, persistence across reload. 10/10 stable locally.
- `test.describe.configure({ mode: "serial" })` for this file. The implementation works fine under real concurrent use; the serial mode is only because Playwright's small drag windows are sensitive to dev-server slowdown when many workers compile at once.

## Drive-by fixes (called out in #35)

I hit two test-DX papercuts and patched them in the same commit; happy to split into a separate PR if you'd rather:

1. `vantage serve` in `playwright.config.ts`'s `webServer` opens the system default browser on every test run (Safari on macOS by default), repeatedly stealing focus. Fix: pass `--no-open`.
2. `playwright.config.ts` ships without a `channel`, so it uses bundled Chromium. Switched to `channel: "chrome"` so headed debugging uses the developer's installed Chrome.

## Test plan

- [x] `npx playwright test sidebar_resize.spec.ts` — 7 passed × 10 consecutive runs
- [x] `npx playwright test sidebar.spec.ts` — still passes the navigation test (the existing "expands directory to show children" test is a pre-existing flake on `main` unrelated to this change)
- [x] Manual: drag handle in browser, reload, confirm width restored; collapse + reopen sidebar, confirm width restored
- [x] Manual: resize below MIN and above MAX, confirm clamps